### PR TITLE
Do not use isFileEncryptedNativeOrEmulated() on Android 14 and later

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.RuntimeEnvironment.getApplication;
 import static org.robolectric.Shadows.shadowOf;
@@ -18,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
 
 /** Unit tests for {@link ShadowStorageManager}. */
 @RunWith(AndroidJUnit4.class)
@@ -77,10 +79,15 @@ public class ShadowStorageManagerTest {
   }
 
   @Test
-  @Config(minSdk = N)
+  @Config(minSdk = N, maxSdk = TIRAMISU)
   public void isFileEncryptedNativeOrEmulated() {
     shadowOf(storageManager).setFileEncryptedNativeOrEmulated(true);
-    assertThat(StorageManager.isFileEncryptedNativeOrEmulated()).isTrue();
+    // Use reflection, as this method is planned to be removed from StorageManager in V.
+    assertThat(
+            (boolean)
+                ReflectionHelpers.callStaticMethod(
+                    StorageManager.class, "isFileEncryptedNativeOrEmulated"))
+        .isTrue();
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.TIRAMISU;
 
 import android.os.UserManager;
 import android.os.storage.StorageManager;
@@ -83,8 +84,10 @@ public class ShadowStorageManager {
     return null;
   }
 
+  // Use maxSdk=T for this method, since starting in U, this method in StorageManager is deprecated
+  // and is no longer called by the Android framework. It's planned to be removed entirely in V.
   @HiddenApi
-  @Implementation(minSdk = N)
+  @Implementation(minSdk = N, maxSdk = TIRAMISU)
   protected static boolean isFileEncryptedNativeOrEmulated() {
     return isFileEncryptionSupported;
   }


### PR DESCRIPTION
Starting in Android 14 (U), the hidden static method StorageManager#isFileEncryptedNativeOrEmulated() is deprecated and has no callers other than robolectric.  Therefore, stop depending on it. This unblocks the removal of this obsolete code.